### PR TITLE
複数モデルの値を一括で登録できるようにする

### DIFF
--- a/app/controllers/bugs_controller.rb
+++ b/app/controllers/bugs_controller.rb
@@ -19,29 +19,27 @@ class BugsController < ApplicationController
   end
 
   def new
-    @bug_radar_chart = BugRadarChartForm.new
+    @bug_radar_chart_form = BugRadarChartForm.new
   end
 
   def edit; end
 
   def create
-    @bug_radar_chart = BugRadarChartForm.new(bug_radar_chart_params)
-    @bug_radar_chart.save!
+    @bug_radar_chart_form = BugRadarChartForm.new(bug_radar_chart_params)
+    @bug_radar_chart_form.save!
     @bug = Bug.last
     redirect_to @bug, success: '登録しました'
   rescue ActiveRecord::RecordInvalid => e
-    @bug_radar_chart = e.record
+    @bug_radar_chart_form = e.record
     flash.now[:danger] = '登録できませんでした'
     render :new
   end
 
   def update
-    if @bug.update(bug_params)
+    @bug_radar_chart = BugRadarChartForm.new(bug_params)
       redirect_to @bug, success: '更新しました'
-    else
       flash.now[:danger] = '更新できませんでした'
       render :new
-    end
   end
 
   def destroy
@@ -80,7 +78,7 @@ class BugsController < ApplicationController
   end
 
   def bug_radar_chart_params
-    params[:bug_radar_chart]&.permit(:name, :feature, :approach, :prevention, :harm, 
+    params.require(:bug_radar_chart_form).permit(:name, :feature, :approach, :prevention, :harm, 
                                      :size, :color, :season, :capture, :breeding,
                                      :prevention_difficulty, :injury, :discomfort, 
                                      :image).merge(user_id: current_user.id)

--- a/app/controllers/bugs_controller.rb
+++ b/app/controllers/bugs_controller.rb
@@ -14,7 +14,7 @@ class BugsController < ApplicationController
   def show
     @bug = Bug.find(params[:id])
     @radar_chart = @bug.radar_chart
-    @other_bug = Bug.includes(:radar_chart).where.not(id: @bug.id).shuffle.first
+    @other_bug = Bug.includes(:radar_chart).where.not(id: @bug.id).sample
     @comments = @bug.comments.order(created_at: :desc)
     @comment = Comment.new
     @url = bug_comments_path(@bug)
@@ -80,11 +80,11 @@ class BugsController < ApplicationController
   end
 
   def set_bug_radar_chart_form
-    @bug_radar_chart_form = BugRadarChartForm.new(name: @bug.name, feature: @bug.feature, approach: @bug.approach, 
-                                                  prevention: @bug.prevention, harm: @bug.harm, size: @bug.size, 
-                                                  color: @bug.color, season: @bug.season, capture: @radar_chart.capture, 
-                                                  breeding: @radar_chart.breeding, injury: @radar_chart.injury,  
-                                                  prevention_difficulty: @radar_chart.prevention_difficulty, 
+    @bug_radar_chart_form = BugRadarChartForm.new(name: @bug.name, feature: @bug.feature, approach: @bug.approach,
+                                                  prevention: @bug.prevention, harm: @bug.harm, size: @bug.size,
+                                                  color: @bug.color, season: @bug.season, capture: @radar_chart.capture,
+                                                  breeding: @radar_chart.breeding, injury: @radar_chart.injury,
+                                                  prevention_difficulty: @radar_chart.prevention_difficulty,
                                                   discomfort: @radar_chart.discomfort)
   end
 
@@ -94,9 +94,9 @@ class BugsController < ApplicationController
   end
 
   def bug_radar_chart_form_params
-    params.require(:bug_radar_chart_form).permit(:name, :feature, :approach, :prevention, :harm, 
+    params.require(:bug_radar_chart_form).permit(:name, :feature, :approach, :prevention, :harm,
                                                  :size, :color, :season, :capture, :breeding,
-                                                 :prevention_difficulty, :injury, :discomfort, 
+                                                 :prevention_difficulty, :injury, :discomfort,
                                                  :image).merge(user_id: current_user.id)
   end
 end

--- a/app/forms/bug_radar_chart_form.rb
+++ b/app/forms/bug_radar_chart_form.rb
@@ -19,17 +19,29 @@ class BugRadarChartForm
 
   attr_accessor :image
 
-  def save!
+  def create!
     ActiveRecord::Base.transaction do
-      bug = Bug.new(name: name, feature: feature, approach: approach, 
+      bug = Bug.create!(name: name, feature: feature, approach: approach, 
                      prevention: prevention, harm: harm, size: size, 
                      color: color, season: season, user_id: user_id, image: image)
-      bug.save!
 
-      radar_chart = bug.build_radar_chart(capture: capture, breeding: breeding, 
+      radar_chart = bug.create_radar_chart!(capture: capture, breeding: breeding, 
                                           prevention_difficulty: prevention_difficulty, 
                                           injury: injury, discomfort: discomfort)
-      radar_chart.save!
+    end
+  end
+
+  def update!(bug, radar_chart)
+    ActiveRecord::Base.transaction do
+      bug.update!(name: name, feature: feature, approach: approach, 
+                             prevention: prevention, harm: harm, size: size, 
+                             color: color, season: season, user_id: user_id)
+
+      radar_chart.update!(capture: capture, breeding: breeding, 
+                                     prevention_difficulty: prevention_difficulty, 
+                                     injury: injury, discomfort: discomfort)
+                                     
+      bug.image.attach(image) if image.present?
     end
   end
 end

--- a/app/forms/bug_radar_chart_form.rb
+++ b/app/forms/bug_radar_chart_form.rb
@@ -21,26 +21,26 @@ class BugRadarChartForm
 
   def create!
     ActiveRecord::Base.transaction do
-      bug = Bug.create!(name: name, feature: feature, approach: approach, 
-                     prevention: prevention, harm: harm, size: size, 
-                     color: color, season: season, user_id: user_id, image: image)
+      bug = Bug.create!(name: name, feature: feature, approach: approach,
+                        prevention: prevention, harm: harm, size: size,
+                        color: color, season: season, user_id: user_id, image: image)
 
-      radar_chart = bug.create_radar_chart!(capture: capture, breeding: breeding, 
-                                          prevention_difficulty: prevention_difficulty, 
-                                          injury: injury, discomfort: discomfort)
+      bug.create_radar_chart!(capture: capture, breeding: breeding,
+                              prevention_difficulty: prevention_difficulty,
+                              injury: injury, discomfort: discomfort)
     end
   end
 
   def update!(bug, radar_chart)
     ActiveRecord::Base.transaction do
-      bug.update!(name: name, feature: feature, approach: approach, 
-                             prevention: prevention, harm: harm, size: size, 
-                             color: color, season: season, user_id: user_id)
+      bug.update!(name: name, feature: feature, approach: approach,
+                  prevention: prevention, harm: harm, size: size,
+                  color: color, season: season, user_id: user_id)
 
-      radar_chart.update!(capture: capture, breeding: breeding, 
-                                     prevention_difficulty: prevention_difficulty, 
-                                     injury: injury, discomfort: discomfort)
-                                     
+      radar_chart.update!(capture: capture, breeding: breeding,
+                          prevention_difficulty: prevention_difficulty,
+                          injury: injury, discomfort: discomfort)
+
       bug.image.attach(image) if image.present?
     end
   end

--- a/app/forms/bug_radar_chart_form.rb
+++ b/app/forms/bug_radar_chart_form.rb
@@ -1,0 +1,35 @@
+class BugRadarChartForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :name, :string
+  attribute :feature, :string
+  attribute :approach, :string
+  attribute :prevention, :string
+  attribute :harm, :string
+  attribute :size, :string
+  attribute :color, :string
+  attribute :season, :string
+  attribute :capture, :integer
+  attribute :breeding, :integer
+  attribute :prevention_difficulty, :integer
+  attribute :injury, :integer
+  attribute :discomfort, :integer
+  attribute :user_id, :integer
+
+  attr_accessor :image
+
+  def save!
+    ActiveRecord::Base.transaction do
+      bug = Bug.new(name: name, feature: feature, approach: approach, 
+                     prevention: prevention, harm: harm, size: size, 
+                     color: color, season: season, user_id: user_id, image: image)
+      bug.save!
+
+      radar_chart = bug.build_radar_chart(capture: capture, breeding: breeding, 
+                                          prevention_difficulty: prevention_difficulty, 
+                                          injury: injury, discomfort: discomfort)
+      radar_chart.save!
+    end
+  end
+end

--- a/app/forms/search_bugs_form.rb
+++ b/app/forms/search_bugs_form.rb
@@ -2,7 +2,6 @@ class SearchBugsForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :name, :string
   attribute :size, :string
   attribute :color, :string
   attribute :season, :string

--- a/app/models/bug.rb
+++ b/app/models/bug.rb
@@ -10,10 +10,10 @@ class Bug < ApplicationRecord
   enum season: { spring: 1, summer: 2, autumn: 3, winter: 4 }
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 50 }
-  validates :feature, length: { maximum: 3_000 }
-  validates :approach, length: { maximum: 3_000 }
-  validates :prevention, length: { maximum: 3_000 }
-  validates :harm, length: { maximum: 3_000 }
+  validates :feature, length: { maximum: 3000 }
+  validates :approach, length: { maximum: 3000 }
+  validates :prevention, length: { maximum: 3000 }
+  validates :harm, length: { maximum: 3000 }
 
   scope :high_chart, ->(column) { joins(:radar_chart).where(radar_charts: { column => [8, 9, 10] }) }
   scope :normal_chart, ->(column) { joins(:radar_chart).where(radar_charts: { column => [4, 5, 6, 7] }) }

--- a/app/models/radar_chart.rb
+++ b/app/models/radar_chart.rb
@@ -1,10 +1,10 @@
 class RadarChart < ApplicationRecord
   belongs_to :bug
 
-  validates :capture, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 10 }
-  validates :breeding, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 10 }
+  validates :capture, presence: true, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }
+  validates :breeding, presence: true, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }
   validates :prevention_difficulty, presence: true,
-                                    numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 10 }
-  validates :injury, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 10 }
-  validates :discomfort, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 10 }
+                                    numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }
+  validates :injury, presence: true, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }
+  validates :discomfort, presence: true, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_comments, through: :likes, source: :comment
 
-  validates :password, length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, length: { minimum: 5 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 

--- a/app/views/bugs/_form.html.erb
+++ b/app/views/bugs/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form py-3 px-4 my-3">
-  <%= form_with model: bug_radar_chart, url: bugs_path, scope: :bug_radar_chart, method: :post, local: true do |f| %>
+  <%= form_with model: bug_radar_chart_form, url: url, scope: :bug_radar_chart_form, local: true do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <div class="form-group mb-3">
       <%= f.label :name %>
@@ -46,27 +46,27 @@
     <div class="row">
       <div class="form-group mb-3 col-2 offset-1">
         <%= f.label :capture %>
-        <%= f.select :capture, (1..10).map{ |n| [n]}, { include_blank: '指定なし' }, class: 'form-select' %>
+        <%= f.select :capture, (1..10).map{ |n| [n]}, class: 'form-select' %>
       </div>
 
       <div class="form-group mb-3 col-2">
         <%= f.label :breeding %>
-        <%= f.select :breeding, (1..10).map{ |n| [n]}, { include_blank: '指定なし' }, class: 'form-select' %>
+        <%= f.select :breeding, (1..10).map{ |n| [n]}, class: 'form-select' %>
       </div>
 
       <div class="form-group mb-3 col-2">
         <%= f.label :prevention_difficulty %>
-        <%= f.select :prevention_difficulty, (1..10).map{ |n| [n]}, { include_blank: '指定なし' }, class: 'form-select' %>
+        <%= f.select :prevention_difficulty, (1..10).map{ |n| [n]}, class: 'form-select' %>
       </div>
 
       <div class="form-group mb-3 col-2">
         <%= f.label :injury %>
-        <%= f.select :injury, (1..10).map{ |n| [n]}, { include_blank: '指定なし' }, class: 'form-select' %>
+        <%= f.select :injury, (1..10).map{ |n| [n]}, class: 'form-select' %>
       </div>
 
       <div class="form-group mb-3 col-2">
         <%= f.label :discomfort %>
-        <%= f.select :discomfort, (1..10).map{ |n| [n]}, { include_blank: '指定なし' }, class: 'form-select' %>
+        <%= f.select :discomfort, (1..10).map{ |n| [n]}, class: 'form-select' %>
       </div>
     </div>
 

--- a/app/views/bugs/_form.html.erb
+++ b/app/views/bugs/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form py-3 px-4 my-3">
-  <%= form_with model: bug, local: true do |f| %>
+  <%= form_with model: bug_radar_chart, url: bugs_path, scope: :bug_radar_chart, method: :post, local: true do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <div class="form-group mb-3">
       <%= f.label :name %>
@@ -43,6 +43,33 @@
       </div>
     </div>
 
+    <div class="row">
+      <div class="form-group mb-3 col-2 offset-1">
+        <%= f.label :capture %>
+        <%= f.select :capture, (1..10).map{ |n| [n]}, { include_blank: '指定なし' }, class: 'form-select' %>
+      </div>
+
+      <div class="form-group mb-3 col-2">
+        <%= f.label :breeding %>
+        <%= f.select :breeding, (1..10).map{ |n| [n]}, { include_blank: '指定なし' }, class: 'form-select' %>
+      </div>
+
+      <div class="form-group mb-3 col-2">
+        <%= f.label :prevention_difficulty %>
+        <%= f.select :prevention_difficulty, (1..10).map{ |n| [n]}, { include_blank: '指定なし' }, class: 'form-select' %>
+      </div>
+
+      <div class="form-group mb-3 col-2">
+        <%= f.label :injury %>
+        <%= f.select :injury, (1..10).map{ |n| [n]}, { include_blank: '指定なし' }, class: 'form-select' %>
+      </div>
+
+      <div class="form-group mb-3 col-2">
+        <%= f.label :discomfort %>
+        <%= f.select :discomfort, (1..10).map{ |n| [n]}, { include_blank: '指定なし' }, class: 'form-select' %>
+      </div>
+    </div>
+
     <div class="image_input">
       <div class="form-group mb-3 col-6">
         <%= f.label :image %>
@@ -51,13 +78,6 @@
       <div class="mb-3">
         <img id="registar_image_preview", style="display: none;" />
       </div>
-    </div>
-
-    <div class="current_image mb-3">
-      <% if bug.image.attached? %>
-        <p class="mb-2">現在の画像</p>
-        <%= image_tag bug.image, size: '350x250', class: 'border border-dark' %>
-      <% end %>
     </div>
     
     <div class="actions mb-3">

--- a/app/views/bugs/_form.html.erb
+++ b/app/views/bugs/_form.html.erb
@@ -79,6 +79,13 @@
         <img id="registar_image_preview", style="display: none;" />
       </div>
     </div>
+
+    <div class="current_image mb-3">
+      <% if bug.image.attached? %>
+        <p class="mb-2">現在の画像</p>
+        <%= image_tag bug.image, size: '350x250', class: 'border border-dark' %>
+      <% end %>
+    </div>
     
     <div class="actions mb-3">
       <%= f.submit class: 'btn btn-primary' %>

--- a/app/views/bugs/edit.html.erb
+++ b/app/views/bugs/edit.html.erb
@@ -4,7 +4,100 @@
     <h1 class="mb-4 pb-2 border-bottom border-dark">虫を編集する</h1>
     <div class="row">
       <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-        <%= render 'form', bug_radar_chart_form: @bug_radar_chart_form, url: bug_path(@bug) %>
+        <div class="form py-3 px-4 my-3">
+          <%= form_with model: @bug_radar_chart_form, url: bug_path(@bug), scope: :bug_radar_chart_form, method: :patch, local: true do |f| %>
+            <%= render 'shared/error_messages', object: f.object %>
+            <div class="form-group mb-3">
+              <%= f.label :name %>
+              <%= f.text_field :name, class: 'form-control', placeholder: '害虫の名前を入力してください。' %>
+            </div>
+
+            <div class="form-group mb-3">
+              <%= f.label :feature %>
+              <%= f.text_area :feature, class: 'form-control', placeholder: '害虫の特徴を入力してください。', rows: 7 %>
+            </div>
+
+            <div class="form-group mb-3">
+              <%= f.label :approach %>
+              <%= f.text_area :approach, class: 'form-control', placeholder: '害虫の駆除方法を入力してください', rows: 7 %>
+            </div>
+
+            <div class="form-group mb-3">
+              <%= f.label :prevention %>
+              <%= f.text_area :prevention, class: 'form-control', placeholder: '害虫の予防方法を入力してください。', rows: 7 %>
+            </div>
+
+            <div class="form-group mb-3">
+              <%= f.label :harm %>
+              <%= f.text_area :harm, class: 'form-control', placeholder: '害虫の実害を入力してください。', rows: 7 %>
+            </div>
+
+            <div class="row">
+              <div class="form-group mb-3 col-sm-12 col-lg-4">
+                <%= f.label :size %>
+                <%= f.select :size, Bug.sizes_i18n.invert, { include_blank: '選択してください' }, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-sm-12 col-lg-4">
+                <%= f.label :color %>
+                <%= f.select :color, Bug.colors_i18n.invert, { include_blank: '選択してください' }, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-sm-12 col-lg-4">
+                <%= f.label :season %>
+                <%= f.select :season, Bug.seasons_i18n.invert, { include_blank: '選択してください' }, class: 'form-select' %>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="form-group mb-3 col-2 offset-1">
+                <%= f.label :攻略度 %>
+                <%= f.select :capture, (1..10).map{ |n| [n]}, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-2">
+                <%= f.label :繁殖力 %>
+                <%= f.select :breeding, (1..10).map{ |n| [n]}, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-2">
+                <%= f.label :予防難度 %>
+                <%= f.select :prevention_difficulty, (1..10).map{ |n| [n]}, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-2 offset-1">
+                <%= f.label :害 %>
+                <%= f.select :injury, (1..10).map{ |n| [n]}, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-2">
+                <%= f.label :不快感 %>
+                <%= f.select :discomfort, (1..10).map{ |n| [n]}, class: 'form-select' %>
+              </div>
+            </div>
+
+            <div class="image_input">
+              <div class="form-group mb-3 col-6">
+                <%= f.label :image %>
+                <%= f.file_field :image, class: 'form-control', id: 'registar_image', accept: 'image/png, image/jpeg' %>
+              </div>
+              <div class="mb-3">
+                <img id="registar_image_preview", style="display: none;" />
+              </div>
+            </div>
+
+            <div class="current_image mb-3">
+              <% if @bug.image.attached? %>
+                <p class="mb-2">現在の画像</p>
+                <%= image_tag @bug.image, size: '350x250', class: 'border border-dark' %>
+              <% end %>
+            </div>
+            
+            <div class="actions mb-3">
+              <%= f.submit class: 'btn btn-primary' %>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/bugs/edit.html.erb
+++ b/app/views/bugs/edit.html.erb
@@ -94,7 +94,7 @@
             </div>
             
             <div class="actions mb-3">
-              <%= f.submit class: 'btn btn-primary' %>
+              <%= f.submit '更新する', class: 'btn btn-primary' %>
             </div>
           <% end %>
         </div>

--- a/app/views/bugs/edit.html.erb
+++ b/app/views/bugs/edit.html.erb
@@ -4,7 +4,7 @@
     <h1 class="mb-4 pb-2 border-bottom border-dark">虫を編集する</h1>
     <div class="row">
       <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-        <%= render 'form', bug: @bug %>
+        <%= render 'form', bug_radar_chart_form: @bug_radar_chart_form, url: bug_path(@bug) %>
       </div>
     </div>
   </div>

--- a/app/views/bugs/new.html.erb
+++ b/app/views/bugs/new.html.erb
@@ -4,7 +4,7 @@
     <h1 class="mb-4 pb-2 border-bottom border-dark">家にいる不快な虫を登録</h1>
     <div class="row">
       <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-        <%= render 'form', bug_radar_chart: @bug_radar_chart %>
+        <%= render 'form', bug_radar_chart_form: @bug_radar_chart_form, url: bugs_path %>
       </div>
     </div>
   </div>

--- a/app/views/bugs/new.html.erb
+++ b/app/views/bugs/new.html.erb
@@ -4,7 +4,7 @@
     <h1 class="mb-4 pb-2 border-bottom border-dark">家にいる不快な虫を登録</h1>
     <div class="row">
       <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-        <%= render 'form', bug: @bug %>
+        <%= render 'form', bug_radar_chart: @bug_radar_chart %>
       </div>
     </div>
   </div>

--- a/app/views/bugs/new.html.erb
+++ b/app/views/bugs/new.html.erb
@@ -4,7 +4,100 @@
     <h1 class="mb-4 pb-2 border-bottom border-dark">家にいる不快な虫を登録</h1>
     <div class="row">
       <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-        <%= render 'form', bug_radar_chart_form: @bug_radar_chart_form, url: bugs_path %>
+        <div class="form py-3 px-4 my-3">
+          <%= form_with model: @bug_radar_chart_form, url: bugs_path, scope: :bug_radar_chart_form, local: true do |f| %>
+            <%= render 'shared/error_messages', object: f.object %>
+            <div class="form-group mb-3">
+              <%= f.label :name %>
+              <%= f.text_field :name, class: 'form-control', placeholder: '害虫の名前を入力してください。' %>
+            </div>
+
+            <div class="form-group mb-3">
+              <%= f.label :feature %>
+              <%= f.text_area :feature, class: 'form-control', placeholder: '害虫の特徴を入力してください。', rows: 7 %>
+            </div>
+
+            <div class="form-group mb-3">
+              <%= f.label :approach %>
+              <%= f.text_area :approach, class: 'form-control', placeholder: '害虫の駆除方法を入力してください', rows: 7 %>
+            </div>
+
+            <div class="form-group mb-3">
+              <%= f.label :prevention %>
+              <%= f.text_area :prevention, class: 'form-control', placeholder: '害虫の予防方法を入力してください。', rows: 7 %>
+            </div>
+
+            <div class="form-group mb-3">
+              <%= f.label :harm %>
+              <%= f.text_area :harm, class: 'form-control', placeholder: '害虫の実害を入力してください。', rows: 7 %>
+            </div>
+
+            <div class="row">
+              <div class="form-group mb-3 col-sm-12 col-lg-4">
+                <%= f.label :size %>
+                <%= f.select :size, Bug.sizes_i18n.invert, { include_blank: '選択してください' }, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-sm-12 col-lg-4">
+                <%= f.label :color %>
+                <%= f.select :color, Bug.colors_i18n.invert, { include_blank: '選択してください' }, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-sm-12 col-lg-4">
+                <%= f.label :season %>
+                <%= f.select :season, Bug.seasons_i18n.invert, { include_blank: '選択してください' }, class: 'form-select' %>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="form-group mb-3 col-lg-2 offset-1">
+                <%= f.label :攻略度 %>
+                <%= f.select :capture, (1..10).map{ |n| [n]}, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-lg-2">
+                <%= f.label :繁殖力 %>
+                <%= f.select :breeding, (1..10).map{ |n| [n]}, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-lg-2">
+                <%= f.label :予防難度 %>
+                <%= f.select :prevention_difficulty, (1..10).map{ |n| [n]}, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-lg-2 offset-1">
+                <%= f.label :害 %>
+                <%= f.select :injury, (1..10).map{ |n| [n]}, class: 'form-select' %>
+              </div>
+
+              <div class="form-group mb-3 col-lg-2">
+                <%= f.label :不快感 %>
+                <%= f.select :discomfort, (1..10).map{ |n| [n]}, class: 'form-select' %>
+              </div>
+            </div>
+
+            <div class="image_input">
+              <div class="form-group mb-3 col-6">
+                <%= f.label :image %>
+                <%= f.file_field :image, class: 'form-control', id: 'registar_image', accept: 'image/png, image/jpeg' %>
+              </div>
+              <div class="mb-3">
+                <img id="registar_image_preview", style="display: none;" />
+              </div>
+            </div>
+
+            <div class="current_image mb-3">
+              <% if @bug.image.attached? %>
+                <p class="mb-2">現在の画像</p>
+                <%= image_tag @bug.image, size: '350x250', class: 'border border-dark' %>
+              <% end %>
+            </div>
+            
+            <div class="actions mb-3">
+              <%= f.submit class: 'btn btn-primary' %>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/bugs/show.html.erb
+++ b/app/views/bugs/show.html.erb
@@ -16,15 +16,7 @@
           <% end %>
         </div>
         <div class="radar-chart">
-          <% if @bug.radar_chart %>
-            <%= render 'radar_charts/radar_chart', bug: @bug, other_bug: @other_bug %>
-            <div class="float-end">
-              <%= link_to 'レーダーチャートを編集する', edit_bug_radar_chart_path(@bug) if current_user&.own?(@bug) %>
-            </div>
-          <% else %>
-            <p class="text-center">レーダーチャートがありません</p>
-            <%= link_to 'レーダーチャートを作成する', new_bug_radar_chart_path(@bug) if current_user&.own?(@bug) %>
-          <% end %>
+          <%= render 'radar_charts/radar_chart', bug: @bug, other_bug: @other_bug %>
         </div>
       </div>
       <div class="bug-text-contents">

--- a/app/views/radar_charts/_radar_chart.html.erb
+++ b/app/views/radar_charts/_radar_chart.html.erb
@@ -10,19 +10,21 @@ var myChart = new Chart(ctx, {
         {
         label: "<%= bug.name %>",
         data: [<%= bug.radar_chart.capture %>, <%= bug.radar_chart.breeding %>, <%= bug.radar_chart.prevention_difficulty %>, <%= bug.radar_chart.injury %>, <%= bug.radar_chart.discomfort %>],
-        backgroundColor: 'rgba(85,107,47,0.3)',
-        borderColor: 'rgba(85,107,47)',
+        backgroundColor: 'rgba(255,99,71,0.4)',
+        borderColor: 'rgba(255,0,0)',
         borderWidth: 1,
-        pointBackgroundColor: 'rgb(46,106,177)'
+        pointBackgroundColor: 'rgba(255,0,0)'
         },
-        {
-          label: "<%= other_bug.name %>",
-          data: [<%= other_bug.radar_chart.capture %>, <%= other_bug.radar_chart.breeding %>, <%= other_bug.radar_chart.prevention_difficulty %>, <%= other_bug.radar_chart.injury %>, <%= other_bug.radar_chart.discomfort %>],
-          backgroundColor: 'rgba(204,204,153,0.3)',
-          borderColor: 'rgba(122,255,129,0.2)',
-          borderWidth: 1,
-          pointBackgroundColor: 'RGB(46,106,177)'
-          }
+        <% if other_bug.present? %>
+          {
+            label: "<%= other_bug.name %>",
+            data: [<%= other_bug.radar_chart.capture %>, <%= other_bug.radar_chart.breeding %>, <%= other_bug.radar_chart.prevention_difficulty %>, <%= other_bug.radar_chart.injury %>, <%= other_bug.radar_chart.discomfort %>],
+            backgroundColor: 'rgba(0,255,255,0.3)',
+            borderColor: 'rgb(0,0,255)',
+            borderWidth: 1,
+            pointBackgroundColor: 'rgb(0,0,255)'
+            }
+        <% end %>
     ]
   },
   options: {

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -97,3 +97,18 @@ ja:
         discomfort_high: 高い
         discomfort_normal: 普通
         discomfort_low: 低い
+      bug_radar_chart_form:
+        name: 名前
+        feature: 特徴
+        approach: 駆除方法
+        prevention: 予防方法
+        harm: 実害
+        size: 大きさ
+        color: 色
+        season: 季節
+        image: 画像
+        capture: 攻略度
+        breeding: 繁殖力
+        prevention_difficulty: 予防難度
+        injury: 害
+        discomfort: 不快感

--- a/spec/system/bugs_spec.rb
+++ b/spec/system/bugs_spec.rb
@@ -26,12 +26,13 @@ RSpec.describe 'Bugs', type: :system do
 
     context '詳細ページ' do
       let!(:radar_chart) { create(:radar_chart, bug: bug) }
-      let!(:edit_bug) { create(:bug, user: user) }
+      let(:edit_bug) { create(:bug, user: user) }
+      let!(:radar_chart_with_edit_bug) { create(:radar_chart, bug: edit_bug) }
 
       before do
         login user
         visit edit_bug_path(edit_bug)
-        attach_file 'bug[image]', "#{Rails.root}/spec/fixtures/images/default.png"
+        attach_file 'bug_radar_chart_form[image]', "#{Rails.root}/spec/fixtures/images/default.png"
         click_on '更新する'
         logout
         visit bug_path(edit_bug)
@@ -67,15 +68,15 @@ RSpec.describe 'Bugs', type: :system do
     context '新規作成ページ' do
       it '有効な値を入れると新規作成に成功する' do
         visit new_bug_path
-        fill_in 'bug[name]', with: '害虫の名前'
-        fill_in 'bug[feature]', with: '害虫の特徴'
-        fill_in 'bug[approach]', with: '害虫の駆除方法'
-        fill_in 'bug[prevention]', with: '害虫の予防方法'
-        fill_in 'bug[harm]', with: '害虫の実害'
-        select '選択してください', from: 'bug[size]'
-        select '黒', from: 'bug[color]'
-        select '春', from: 'bug[season]'
-        attach_file 'bug[image]', "#{Rails.root}/spec/fixtures/images/default.png"
+        fill_in 'bug_radar_chart_form[name]', with: '害虫の名前'
+        fill_in 'bug_radar_chart_form[feature]', with: '害虫の特徴'
+        fill_in 'bug_radar_chart_form[approach]', with: '害虫の駆除方法'
+        fill_in 'bug_radar_chart_form[prevention]', with: '害虫の予防方法'
+        fill_in 'bug_radar_chart_form[harm]', with: '害虫の実害'
+        select '選択してください', from: 'bug_radar_chart_form[size]'
+        select '黒', from: 'bug_radar_chart_form[color]'
+        select '春', from: 'bug_radar_chart_form[season]'
+        attach_file 'bug_radar_chart_form[image]', "#{Rails.root}/spec/fixtures/images/default.png"
         click_on '登録する'
         expect(page).to have_content '登録しました'
         expect(Bug.count).to eq 2
@@ -92,13 +93,15 @@ RSpec.describe 'Bugs', type: :system do
     end
 
     context '編集ページ' do
+      let!(:radar_chart) { create(:radar_chart, bug: bug) }
       let(:edit_bug) { create(:bug, user: user) }
+      let!(:radar_chart_with_edit_bug) { create(:radar_chart, bug: edit_bug) }
 
       it '有効な値を入れると更新できる' do
         visit bug_path(edit_bug)
         click_on '編集'
-        fill_in 'bug[feature]', with: '特徴を更新します'
-        select '冬', from: 'bug[season]'
+        fill_in 'bug_radar_chart_form[feature]', with: '特徴を更新します'
+        select '冬', from: 'bug_radar_chart_form[season]'
         click_on '更新する'
         expect(page).to have_content '更新しました'
         expect(current_path).to eq bug_path(edit_bug)
@@ -106,7 +109,7 @@ RSpec.describe 'Bugs', type: :system do
 
       it '名前を空欄にすると更新に失敗する' do
         visit edit_bug_path(edit_bug)
-        fill_in 'bug[name]', with: nil
+        fill_in 'bug_radar_chart_form[name]', with: nil
         click_on '更新する'
         expect(page).to have_content '更新できませんでした'
         expect(page).to have_content '名前を入力してください'

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Comments', type: :system do
   let(:user) { create :user }
   let(:bug) { create :bug }
-  let!(:radar_chart) { create :radar_chart }
+  let!(:radar_chart) { create :radar_chart, bug: bug }
 
   describe 'ログイン前' do
     context 'コメントを投稿する' do

--- a/spec/system/likes_spec.rb
+++ b/spec/system/likes_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Likes', type: :system do
   let(:user) { create(:user) }
   let(:bug) { create(:bug) }
-  let!(:radar_chart) { create(:radar_chart) }
+  let!(:radar_chart) { create(:radar_chart, bug: bug) }
   let(:comment) { create(:comment, bug: bug) }
 
   describe 'ログイン前' do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Users', type: :system do
           fill_in 'user[password]', with: nil
           fill_in 'user[password_confirmation]', with: nil
           click_on '登録'
-          expect(page).to have_content 'パスワードは8文字以上で入力してください'
+          expect(page).to have_content 'パスワードは5文字以上で入力してください'
           expect(page).to have_content 'パスワード(確認)を入力してください'
           expect(current_path).to eq users_path
         end


### PR DESCRIPTION
close #68 
## 概要

- bugモデルのデータとradarchartのデータを一括で保存できるようにする
- form objectを使う

## 確認方法

虫の登録画面で虫の情報とレーダーチャートの値を一括で登録できること。
編集画面で虫の情報とレーダーチャートの値を一括で更新できること。

# コメント
bugモデルのnameカラムのバリデーションに引っ掛かると、radar_chartモデルの値がリセットされてしまう。
radar_chartモデルの値は数字を選択するだけなので、影響は少ないが後で修正する。
