### PR TITLE
ログインせずにいいねができるように修正

### DIFF
--- a/app/controllers/bugs_controller.rb
+++ b/app/controllers/bugs_controller.rb
@@ -18,6 +18,7 @@ class BugsController < ApplicationController
     @comments = @bug.comments.order(created_at: :desc)
     @comment = Comment.new
     @url = bug_comments_path(@bug)
+    @current_ip = request.remote_ip
   end
 
   def new

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,16 +1,18 @@
 class CommentsController < ApplicationController
   include CommentsHelper
-  skip_before_action :require_login, only: :sort
+  skip_before_action :require_login
+  before_action :set_bug, only: :create
 
   def create
-    @comment = current_user.comments.build(comment_params)
+    @current_ip = request.remote_ip
+    @comment = @bug.comments.build(comment_params.merge(global_ip: @current_ip))
     @comment.save
   end
 
   def destroy
-    @comment = current_user.comments.find(params[:id])
+    @comment = Comment.find(params[:id])
+    bug = @comment.bug
     @comment.destroy!
-    bug = Bug.find(params[:bug_id])
     @comments_count = bug.comments.count
   end
 
@@ -22,7 +24,11 @@ class CommentsController < ApplicationController
 
   private
 
+  def set_bug
+    @bug = Bug.find(params[:bug_id])
+  end
+
   def comment_params
-    params.require(:comment).permit(:sentence).merge(bug_id: params[:bug_id])
+    params.require(:comment).permit(:sentence)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,6 +17,7 @@ class CommentsController < ApplicationController
   def sort
     @bug = Bug.find(params[:bug_id])
     @comments = sort_type(params[:type], @bug)
+    @current_ip = request.remote_ip
   end
 
   private

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,11 +1,14 @@
 class LikesController < ApplicationController
+  skip_before_action :require_login
   def create
     @comment = Comment.find(params[:comment_id])
-    current_user.like_comment(@comment)
+    @current_ip = request.remote_ip
+    @comment.likes.create(global_ip: @current_ip)
   end
 
   def destroy
-    @comment = Like.find(params[:id]).comment
-    current_user.unlike_comment(@comment)
+    like = Like.find(params[:id])
+    @comment = like.comment
+    like.destroy!
   end
 end

--- a/app/helpers/search_images_helper.rb
+++ b/app/helpers/search_images_helper.rb
@@ -92,6 +92,6 @@ module SearchImagesHelper
               .or(relation.where('harm LIKE ?', "%#{label}%"))
               .each { |bug| result << bug }
     end
-    result.uniq!
+    bugs_array = result.uniq
   end
 end

--- a/app/helpers/search_images_helper.rb
+++ b/app/helpers/search_images_helper.rb
@@ -92,6 +92,6 @@ module SearchImagesHelper
               .or(relation.where('harm LIKE ?', "%#{label}%"))
               .each { |bug| result << bug }
     end
-    bugs_array = result.uniq
+    result.uniq
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,10 +7,10 @@ class Comment < ApplicationRecord
   scope :sort_like, -> { includes(:likes).sort { |a, b| b.likes.count <=> a.likes.count } }
 
   def post_by(current_ip)
-    self.global_ip == current_ip
+    global_ip == current_ip
   end
 
   def liked_by(global_ip)
-    Like.find_by(comment_id: self.id, global_ip: global_ip)
+    Like.find_by(comment_id: id, global_ip: global_ip)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,11 +1,14 @@
 class Comment < ApplicationRecord
   belongs_to :bug
-  belongs_to :user
   has_many :likes, dependent: :destroy
 
-  validates :sentence, presence: true, length: { maximum: 3_000 }
+  validates :sentence, presence: true, length: { maximum: 3000 }
 
   scope :sort_like, -> { includes(:likes).sort { |a, b| b.likes.count <=> a.likes.count } }
+
+  def post_by(current_ip)
+    self.global_ip == current_ip
+  end
 
   def liked_by(global_ip)
     Like.find_by(comment_id: self.id, global_ip: global_ip)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,4 +6,8 @@ class Comment < ApplicationRecord
   validates :sentence, presence: true, length: { maximum: 3_000 }
 
   scope :sort_like, -> { includes(:likes).sort { |a, b| b.likes.count <=> a.likes.count } }
+
+  def liked_by(global_ip)
+    Like.find_by(comment_id: self.id, global_ip: global_ip)
+  end
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,6 +1,5 @@
 class Like < ApplicationRecord
-  belongs_to :user
   belongs_to :comment
 
-  validates :comment, uniqueness: { scope: :user_id }
+  validates :comment, uniqueness: { scope: :global_ip }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,6 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   has_many :bugs
-  has_many :comments
   # has_many :likes, dependent: :destroy
   # has_many :liked_comments, through: :likes, source: :comment
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,8 @@ class User < ApplicationRecord
 
   has_many :bugs
   has_many :comments
-  has_many :likes, dependent: :destroy
-  has_many :liked_comments, through: :likes, source: :comment
+  # has_many :likes, dependent: :destroy
+  # has_many :liked_comments, through: :likes, source: :comment
 
   validates :password, length: { minimum: 5 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
@@ -13,17 +13,17 @@ class User < ApplicationRecord
   validates :email, uniqueness: { case_sensitive: true }, presence: true
   validates :name, presence: true, length: { maximum: 30 }
 
-  def like_comment(comment)
-    liked_comments << comment
-  end
+  # def like_comment(comment)
+  #   liked_comments << comment
+  # end
 
-  def unlike_comment(comment)
-    liked_comments.destroy(comment)
-  end
+  # def unlike_comment(comment)
+  #   liked_comments.destroy(comment)
+  # end
 
-  def like_comment?(comment)
-    liked_comments.include?(comment)
-  end
+  # def like_comment?(comment)
+  #   liked_comments.include?(comment)
+  # end
 
   def own?(comment)
     id == comment.user_id

--- a/app/views/bugs/_image_search_page.html.erb
+++ b/app/views/bugs/_image_search_page.html.erb
@@ -16,7 +16,8 @@
             <div class="col-12">
               <%= form_with url: image_search_bugs_path, method: :post, local: true do |f| %>
                 <div class="form-group mb-3">
-                  <p style="color: red;">※ファイル形式は`png`か`jpeg`でお願いします。</p>
+                  <p style="color: red;">※ファイル形式(必須): png, jpeg</p>
+                  <p style="color: red;">※ファイルサイズ(推奨): 1MB(1000KB)以下</p>
                   <%= f.file_field :image, class: 'form-control', id: 'input_image', accept: 'image/png, image/jpeg' %>
                 </div>
                 <div class="mb-3">

--- a/app/views/bugs/show.html.erb
+++ b/app/views/bugs/show.html.erb
@@ -42,7 +42,6 @@
     </div>
     <div class="col-sm-12 col-lg-5 offset-lg-1 mb-5 p-3 comment_new">
       <h3 class="mb-3 pb-2 border-bottom border-dark">コメント投稿</h3>
-      <p class="warn_message">※コメントは削除できません。</p>
       <%= render 'comments/form', bug: @bug, comment: @comment, url: @url %>
     </div>
   </div>

--- a/app/views/bugs/show.html.erb
+++ b/app/views/bugs/show.html.erb
@@ -33,17 +33,16 @@
   <div class="row">
     <div class="col-sm-12 col-lg-6 mb-5 p-3 comment_index">
       <h3 class="mb-3 pb-2 border-bottom border-dark">コメント一覧</h3>
-      <p class="warn_message">※いいねにはログインが必要です。</p>
       <div class="comment_order_button">
         <%= render 'comments/comments_sort', bug: @bug %>
       </div>
       <div class="comment-page">
-        <%= render 'comments/comments', comments: @comments %>
+        <%= render 'comments/comments', comments: @comments, current_ip: @current_ip %>
       </div>
     </div>
     <div class="col-sm-12 col-lg-5 offset-lg-1 mb-5 p-3 comment_new">
       <h3 class="mb-3 pb-2 border-bottom border-dark">コメント投稿</h3>
-      <p class="warn_message">※コメントにはログインが必要です。</p>
+      <p class="warn_message">※コメントは削除できません。</p>
       <%= render 'comments/form', bug: @bug, comment: @comment, url: @url %>
     </div>
   </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -2,11 +2,11 @@
   <div class="comment_sentence py-2 px-4">
     <%= safe_join(comment.sentence.split("\n"), tag(:br)) %>
   </div>
-  <div class="delete_or_likes text-end">
-    <% if current_user&.own?(comment) %>
-      <%= link_to '削除', comment_path(comment, 'bug_id': comment.bug_id), method: :delete, data: { confirm: '削除してもよろしいですか？' }, id: 'delete_button', remote: true %>
+  <div class="like_unlike_button text-end">
+    <% if comment.liked_by(current_ip) %>
+      <%= render 'likes/unlike', comment: comment, current_ip: current_ip %>
     <% else %>
-      <%= render 'likes/like_button', comment: comment %>
+      <%= render 'likes/like', comment: comment %>
     <% end %>
     <span>  いいね </span><i id="js-like-count-for-comment-<%= comment.id %>"><%= comment.likes.count %>件</i>
   </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -3,7 +3,7 @@
     <%= safe_join(comment.sentence.split("\n"), tag(:br)) %>
   </div>
   <div class="like_unlike_button text-end">
-    <%= link_to '削除', comment_path(comment), method: :delete, data: { confirm: '削除してもよろしいですか？' }, id: 'delete_button', remote: true if comment.post_by(current_ip) %> / 
+    <%= link_to '削除', comment_path(comment), method: :delete, data: { confirm: '削除してもよろしいですか？' }, id: 'comment_delete_button', remote: true if comment.post_by(current_ip) %> / 
     <% if comment.liked_by(current_ip) %>
       <%= render 'likes/unlike', comment: comment, current_ip: current_ip %>
     <% else %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -3,11 +3,12 @@
     <%= safe_join(comment.sentence.split("\n"), tag(:br)) %>
   </div>
   <div class="like_unlike_button text-end">
+    <%= link_to '削除', comment_path(comment), method: :delete, data: { confirm: '削除してもよろしいですか？' }, id: 'delete_button', remote: true if comment.post_by(current_ip) %> / 
     <% if comment.liked_by(current_ip) %>
       <%= render 'likes/unlike', comment: comment, current_ip: current_ip %>
     <% else %>
       <%= render 'likes/like', comment: comment %>
     <% end %>
-    <span>  いいね </span><i id="js-like-count-for-comment-<%= comment.id %>"><%= comment.likes.count %>件</i>
+    <i id="js-like-count-for-comment-<%= comment.id %>"><%= comment.likes.count %>件</i>
   </div>
 </li>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-12">
     <ul class="comment_list">
-      <%= render comments %>
+      <%= render comments, current_ip: current_ip %>
       <div class="comment_present">
         <%= 'コメントがありません' unless comments.present? %>
       </div>

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -2,7 +2,7 @@ $("#error_massages").remove()
 <% if @comment.errors.present? %>
   $("#new_comment").prepend("<%= j(render('shared/error_messages', object: @comment)) %>")
 <% else %>
-  $(".comment_list").prepend("<%= j(render('comments/comment', comment: @comment)) %>")
+  $(".comment_list").prepend("<%= j(render('comments/comment', comment: @comment, current_ip: @current_ip)) %>")
   $("#js_new_comment_body").val('')
   $(".comment_present").html('')
 <% end %>

--- a/app/views/comments/sort.js.erb
+++ b/app/views/comments/sort.js.erb
@@ -1,1 +1,1 @@
-$('.comment-page').html("<%= j(render('comments/comments', comments: @comments)) %>")
+$('.comment-page').html("<%= j(render('comments/comments', comments: @comments, current_ip: @current_ip)) %>")

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,7 +1,7 @@
 <%= link_to comment_likes_path(comment),
     id: "js-like-button-for-comment-#{comment.id}",
     class: 'like_button',
-    method: :post, 
+    method: :post,
     remote: true do %>
   <i class="far fa-thumbs-up"></i>
 <% end %>

--- a/app/views/likes/_unlike.html.erb
+++ b/app/views/likes/_unlike.html.erb
@@ -1,5 +1,5 @@
-<%= link_to like_path(current_user.likes.find_by(comment_id: comment.id)), 
-    id: "js-like-button-for-comment-#{comment.id}",
+<%= link_to like_path(comment.likes.find_by(global_ip: current_ip)), 
+    id: "js-unlike-button-for-comment-#{comment.id}",
     class: 'unlike_button',
     method: :delete,
     remote: true do %>

--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,3 +1,3 @@
-$("#js-like-button-for-comment-<%= @comment.id %>").replaceWith("<%= j(render('likes/unlike', comment: @comment)) %>");
+$("#js-like-button-for-comment-<%= @comment.id %>").replaceWith("<%= j(render('likes/unlike', comment: @comment, current_ip: @current_ip)) %>");
 
 $("#js-like-count-for-comment-<%= @comment.id %>").html("<%= @comment.likes.count %>件");

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,3 +1,3 @@
-$("#js-like-button-for-comment-<%= @comment.id %>").replaceWith("<%= j(render('likes/like', comment: @comment)) %>");
+$("#js-unlike-button-for-comment-<%= @comment.id %>").replaceWith("<%= j(render('likes/like', comment: @comment)) %>");
 
 $("#js-like-count-for-comment-<%= @comment.id %>").html("<%= @comment.likes.count %>件");

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,6 +25,9 @@
             <% end %>
           </li>
         </ul>
+<% 
+=begin
+%>
         <ul class="navbar-nav justify-content-end">
           <li class="nav-item">
             <% if logged_in? %>
@@ -38,6 +41,9 @@
             <% end %>
           </li>
         </ul>
+<% 
+=end 
+%>
       </div>
     </div>
     </nav>

--- a/db/migrate/20210609131625_create_comments.rb
+++ b/db/migrate/20210609131625_create_comments.rb
@@ -3,7 +3,7 @@ class CreateComments < ActiveRecord::Migration[6.0]
     create_table :comments do |t|
       t.text :sentence, null: false
       t.references :bug, null: false, foreign_key: true
-      t.references :user, null: false, foreign_key: true
+      t.string :global_ip, null: false
 
       t.timestamps
     end

--- a/db/migrate/20210609165040_create_likes.rb
+++ b/db/migrate/20210609165040_create_likes.rb
@@ -1,11 +1,11 @@
 class CreateLikes < ActiveRecord::Migration[6.0]
   def change
     create_table :likes do |t|
-      t.references :user, null: false, foreign_key: true
       t.references :comment, null: false, foreign_key: true
+      t.string :global_ip, null: false
 
       t.timestamps
     end
-    add_index :likes, [:user_id, :comment_id], unique: true
+    add_index :likes, [:global_ip, :comment_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,13 +60,12 @@ ActiveRecord::Schema.define(version: 2021_06_09_165040) do
   end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.bigint "comment_id", null: false
+    t.string "global_ip", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["comment_id"], name: "index_likes_on_comment_id"
-    t.index ["user_id", "comment_id"], name: "index_likes_on_user_id_and_comment_id", unique: true
-    t.index ["user_id"], name: "index_likes_on_user_id"
+    t.index ["global_ip", "comment_id"], name: "index_likes_on_global_ip_and_comment_id", unique: true
   end
 
   create_table "radar_charts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -96,6 +95,5 @@ ActiveRecord::Schema.define(version: 2021_06_09_165040) do
   add_foreign_key "comments", "bugs"
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "comments"
-  add_foreign_key "likes", "users"
   add_foreign_key "radar_charts", "bugs"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,11 +52,10 @@ ActiveRecord::Schema.define(version: 2021_06_09_165040) do
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "sentence", null: false
     t.bigint "bug_id", null: false
-    t.bigint "user_id", null: false
+    t.string "global_ip", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["bug_id"], name: "index_comments_on_bug_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -93,7 +92,6 @@ ActiveRecord::Schema.define(version: 2021_06_09_165040) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bugs", "users"
   add_foreign_key "comments", "bugs"
-  add_foreign_key "comments", "users"
   add_foreign_key "likes", "comments"
   add_foreign_key "radar_charts", "bugs"
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :comment do
     sentence { 'コメントしました' }
-    association :user
+    global_ip { '0.0.0.0' }
     association :bug
   end
 end

--- a/spec/system/bugs_spec.rb
+++ b/spec/system/bugs_spec.rb
@@ -26,26 +26,16 @@ RSpec.describe 'Bugs', type: :system do
 
     context '詳細ページ' do
       let!(:radar_chart) { create(:radar_chart, bug: bug) }
-      let(:edit_bug) { create(:bug, user: user) }
-      let!(:radar_chart_with_edit_bug) { create(:radar_chart, bug: edit_bug) }
-
-      before do
-        login user
-        visit edit_bug_path(edit_bug)
-        attach_file 'bug_radar_chart_form[image]', "#{Rails.root}/spec/fixtures/images/default.png"
-        click_on '更新する'
-        logout
-        visit bug_path(edit_bug)
-      end
 
       it '害虫の詳細が表示される' do
-        expect(page).to have_content edit_bug.name
+        visit bug_path(bug)
+        expect(page).to have_content bug.name
         expect(page).to have_content Bug.human_attribute_name(:feature)
         expect(page).to have_content Bug.human_attribute_name(:approach)
         expect(page).to have_content Bug.human_attribute_name(:prevention)
         expect(page).to have_content Bug.human_attribute_name(:harm)
         expect(page).to have_content Bug.human_attribute_name(:feature)
-        expect(current_path).to eq bug_path(edit_bug)
+        expect(current_path).to eq bug_path(bug)
       end
     end
 

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -1,27 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Comments', type: :system do
-  let(:user) { create :user }
   let(:bug) { create :bug }
   let!(:radar_chart) { create :radar_chart, bug: bug }
 
-  describe 'ログイン前' do
-    context 'コメントを投稿する' do
-      it 'ログイン画面にリダイレクトされる' do
-        visit bug_path(bug)
-        fill_in 'comment[sentence]', with: 'コメントします'
-        click_on 'コメントを投稿する'
-        expect(page).to have_content 'ログインしてください'
-        expect(current_path).to eq login_path
-      end
-    end
-  end
-
-  describe 'ログイン後' do
-    before do
-      login user
-    end
-
+  describe 'コメント投稿機能' do
     context 'コメントを投稿する' do
       it '投稿に成功する' do
         visit bug_path(bug)
@@ -29,7 +12,7 @@ RSpec.describe 'Comments', type: :system do
         click_on 'コメントを投稿する'
         expect(page).not_to have_content 'コメントがありません'
         expect(page).to have_content 'コメントします'
-        expect(page).to have_css '#delete_button'
+        expect(page).to have_css '#comment_delete_button'
         expect(current_path).to eq bug_path(bug)
       end
     end
@@ -40,7 +23,41 @@ RSpec.describe 'Comments', type: :system do
         click_on 'コメントを投稿する'
         expect(page).to have_content 'コメント内容を入力してください'
         expect(page).to have_content 'コメントがありません'
-        expect(page).not_to have_css('#delete_button')
+        expect(page).not_to have_css '#comment_delete_button'
+        expect(current_path).to eq bug_path(bug)
+      end
+    end
+  end
+
+  describe 'コメント削除機能' do
+    context '自分のコメント' do
+      before do
+        visit bug_path(bug)
+        fill_in 'comment[sentence]', with: 'コメントします'
+        click_on 'コメントを投稿する'
+      end
+
+      it '削除に成功する' do
+        expect(page).to have_content 'コメントします'
+        expect(page).to have_css '#comment_delete_button'
+        page.accept_confirm do
+          find('#comment_delete_button').click
+        end
+        expect(page).not_to have_content 'コメントします'
+        expect(page).to have_content 'コメントがありません'
+        expect(page).not_to have_css '#comment_delete_button'
+        expect(current_path).to eq bug_path(bug)
+      end
+    end
+
+    context '他人のコメント' do
+      let!(:comment) { create(:comment, bug: bug) }
+
+      it '削除ボタンが表示されない' do
+        visit bug_path(bug)
+        expect(page).not_to have_content 'コメントがありません'
+        expect(page).to have_content 'コメントしました'
+        expect(page).not_to have_css '#comment_delete_button'
         expect(current_path).to eq bug_path(bug)
       end
     end

--- a/spec/system/likes_spec.rb
+++ b/spec/system/likes_spec.rb
@@ -1,31 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe 'Likes', type: :system do
-  let(:user) { create(:user) }
   let(:bug) { create(:bug) }
   let!(:radar_chart) { create(:radar_chart, bug: bug) }
   let(:comment) { create(:comment, bug: bug) }
 
-  describe 'ログイン前' do
-    it 'いいねを押すとログイン画面にリダイレクトされる' do
-      visit bug_path(comment.bug)
-      find('.like_button').click
-      expect(page).to have_content 'ログインしてください'
-      expect(current_path).to eq login_path
-    end
-  end
-
-  describe 'ログイン後' do
-    before do
-      login user
-    end
-
-    it 'いいねボタンを押すとカウントされ、再度押すと解除される' do
-      visit bug_path(comment.bug)
-      find('.like_button').click
-      expect(find('.comment')).to have_content 1
-      find('.unlike_button').click
-      expect(find('.comment')).to have_content 0
-    end
+  it 'いいねボタンを押すとカウントされ、再度押すと解除される' do
+    visit bug_path(comment.bug)
+    find('.like_button').click
+    expect(find('.comment')).to have_content 1
+    find('.unlike_button').click
+    expect(find('.comment')).to have_content 0
   end
 end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -39,16 +39,16 @@ RSpec.describe 'UserSessions', type: :system do
     end
   end
 
-  describe 'ログアウト機能' do
-    before do
-      login user
-    end
+  # describe 'ログアウト機能' do
+  #   before do
+  #     login user
+  #   end
 
-    it 'ログアウトに成功する' do
-      find('.navbar-toggler').click
-      click_on 'ログアウト'
-      expect(page).to have_content 'ログアウトしました'
-      expect(current_path).to eq root_path
-    end
-  end
+  #   it 'ログアウトに成功する' do
+  #     find('.navbar-toggler').click
+  #     click_on 'ログアウト'
+  #     expect(page).to have_content 'ログアウトしました'
+  #     expect(current_path).to eq root_path
+  #   end
+  # end
 end


### PR DESCRIPTION
close #53 
## 概要

- ログインせずにいいねをできるように修正する
  - ユーザーIDの代わりにグローバルIPアドレスを使用する
  - 虫のレコードのIDとIPアドレスの組み合わせが一意かどうかで判定する
  - likeモデルに`global_ip`カラムを追加 
  - userモデルとlikeモデルのリレーションを解除

-  コメントもログインなしでできるように修正する
   - こちらもIPアドレスを使用して自分のコメントかどうかを判定する
   - commentモデルに`global_ip`カラムを追加 
   - userモデルとcommentモデルのリレーションを解除

## 確認方法

- rspecのテストがパスすること

