### PR TITLE
虫詳細ページの画像のはみだしを修正

### DIFF
--- a/app/javascript/stylesheets/bug_show.scss
+++ b/app/javascript/stylesheets/bug_show.scss
@@ -19,7 +19,7 @@
 }
 
 .bug_image_contents {
-  text-align: center
+  text-align: center;
 }
 
 .show_image_size {
@@ -110,9 +110,19 @@
     width: 95%;
   }
 
+  .bug_show_image {
+    width: 90%;
+  }
+
+  .show_image_size {
+    width: 90%;
+    height: 250px;
+  }
+
   #myTab {
     font-size: small;
   }
+
 
   .bug_comments {
     width: 85%;


### PR DESCRIPTION
close #73 
## 概要

- 虫の詳細ページにアクセスした際、スマホだと画像がはみだすのでcssを修正。

## 確認方法

- スマホで詳細ページにアクセスした際、画像がはみ出していないこと