### PR TITLE
詳細ページから検索結果へ戻る導線を追加

### DIFF
--- a/app/javascript/stylesheets/header.scss
+++ b/app/javascript/stylesheets/header.scss
@@ -10,7 +10,7 @@
 
 .header_transform {
   background: rgba(221, 211, 211, 0.9);
-  padding: 1px 20px;
+  padding: 0px 20px;
 }
 
 .top_margin {

--- a/app/javascript/stylesheets/home.scss
+++ b/app/javascript/stylesheets/home.scss
@@ -44,6 +44,13 @@
   padding-top: 100px;
 }
 
+/*
+.home_search_btn {
+  display: flex;
+  justify-content: center;
+}
+*/
+
 /*スマホ*/
 @media screen and (max-width: 480px) {
 

--- a/app/views/bugs/_word_search_page.html.erb
+++ b/app/views/bugs/_word_search_page.html.erb
@@ -1,6 +1,6 @@
 <!-- Button trigger modal -->
 <%= link_to '#', class: 'nav-link', 'data-bs-toggle': :modal, 'data-bs-target': '#WordSearchModal' do %>
-  <i class="fas fa-search"></i><span> 検索</span>
+  <i class="fas fa-search"></i><span> 通常検索</span>
 <% end %>
 
 <!-- Modal -->

--- a/app/views/bugs/show.html.erb
+++ b/app/views/bugs/show.html.erb
@@ -24,8 +24,9 @@
       </div>
     </div>
   </div>
-  <% if current_user&.own?(@bug) %>
-    <%= link_to '編集', edit_bug_path(@bug) %> |
+  <%= link_to '検索結果に戻る', :back %>
+  <% if current_user&.own?(@bug) %> 
+    | <%= link_to '編集', edit_bug_path(@bug) %> |
     <%= link_to '削除', bug_path(@bug), method: :delete, data: { confirm: '削除してもよろしいですか？' } %>
   <% end %>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,15 +14,16 @@
           <li class="nav-item">
             <%= render '/bugs/image_search_page' %>
           </li>
+        </ul>
+<% 
+=begin
+%>
           <li class="nav-item">
             <%= link_to news_path, class: 'nav-link' do %>
               <i class="fas fa-paper-plane"></i><span> 新着情報</span>
             <% end %>
           </li>
-        </ul>
-<% 
-=begin
-%>
+          
           <li class="nav-item">
             <%= link_to new_bug_path, class: 'nav-link' do %>
               <i class="fas fa-plus-square"></i><span> 新規作成</span>

--- a/spec/system/bugs_spec.rb
+++ b/spec/system/bugs_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'Bugs', type: :system do
         it '検索ワードの入ったレコードのみ表示される' do
           visit root_path
           find('.navbar-toggler').click
-          click_on '検索'
+          click_on '通常検索'
           fill_in 'search[search_word]', with: 'ゴキブリ'
           click_on '検索する'
           expect(page).to have_content name_bug.name
@@ -139,7 +139,7 @@ RSpec.describe 'Bugs', type: :system do
       before do
         visit root_path
         find('.navbar-toggler').click
-        click_on '検索'
+        click_on '通常検索'
       end
 
       context 'サイズを「small」に指定して検索する' do


### PR DESCRIPTION
close #82 
## 概要

- 詳細ページから検索結果へ戻る導線をつくる

## 確認方法

- 詳細ページから検索結果のページに戻れること。
- 検索結果ページに戻った時に、検索結果の検索条件が変わっていないこと。

