### PR TITLE
デザインを修正する

### DIFF
--- a/app/javascript/stylesheets/bug_index.scss
+++ b/app/javascript/stylesheets/bug_index.scss
@@ -3,6 +3,10 @@
   border-radius: 15px;
 }
 
+.card-title {
+  font-size: 23px;
+}
+
 .title_button {
   text-decoration: none;
   color: black;

--- a/app/javascript/stylesheets/bug_index.scss
+++ b/app/javascript/stylesheets/bug_index.scss
@@ -25,7 +25,7 @@
   border-radius: 30px;
 
   &:hover {
-    background: red;
+    background: rgb(50,205,50);
     color: white;
   }
 }
@@ -37,6 +37,7 @@
   border-radius:30px;
 
   &:hover {
-    background: #6ff2fc;
+    background: rgb(0,191,255);
+    color: white;
   }
 }

--- a/app/javascript/stylesheets/bug_show.scss
+++ b/app/javascript/stylesheets/bug_show.scss
@@ -32,7 +32,7 @@
   border-radius:30px;
 
   &:hover {
-    background: red;
+    background: rgb(50,205,50);
     color: white;
   }
 }
@@ -42,7 +42,8 @@
   border-radius:30px;
 
   &:hover {
-    background: #6ff2fc;
+    background: rgb(0,191,255);
+    color: white;
   }
 }
 
@@ -78,7 +79,7 @@
   border-bottom: 2px solid gray;
 
   & .nav-link.active {
-    background-color: #5bc8db;
+    background-color: rgb(50,205,50);
     color: #FFF;
     border-width: 3px;
     border-top-color: gray;
@@ -88,12 +89,28 @@
   }
 
   & .nav-link {
-    color: #4042b1;
+    color: rgb(34,139,34);
   }
 }
 
-.warn_message {
-  color: red;
+.orangered_color {
+  color: rgb(50,205,50);
+
+  &:hover {
+    color: rgb(34,139,34);
+  }
+}
+
+.orangered_btn {
+  background-color: rgb(50,205,50);
+  color: white;
+  border-radius: 15px;
+  padding: 5px 15px;
+
+  &:hover {
+    background-color: rgb(34,139,34);
+    color: white;
+  }
 }
 
 /*pcのときのレーダーチャート*/

--- a/app/javascript/stylesheets/header.scss
+++ b/app/javascript/stylesheets/header.scss
@@ -1,8 +1,7 @@
 .header_body {
-  background: rgba(255,255,255,0.5);
+  background: rgba(0,0,0,0.0);
   padding: 15px 20px;
   width: 100%;
-  box-shadow: 0px 2px 4px gray;
   position: fixed;
   transition: .5s;
   z-index: 1500;
@@ -10,6 +9,7 @@
 
 .header_transform {
   background: rgba(221, 211, 211, 0.9);
+  box-shadow: 0px 2px 4px gray;
   padding: 0px 20px;
 }
 

--- a/app/javascript/stylesheets/home.scss
+++ b/app/javascript/stylesheets/home.scss
@@ -76,7 +76,7 @@
   }
 
   #first_sentence_title {
-    color: rgb(105,105,105);
+    color: rgb(184,134,11);
   }
 
   #second_sentence {

--- a/app/javascript/stylesheets/home.scss
+++ b/app/javascript/stylesheets/home.scss
@@ -4,16 +4,21 @@
   background: no-repeat url('../../assets/images/chair_large.jpeg');
   background-size: 100% 100%;
   background-position: 50% 50%;
+  background-color: rgba(255,255,255,0.4);
+  background-blend-mode: lighten;
 }
 
 #second_sentence {
   padding-top: 150px;
-  padding-bottom: 200px;
-  background-color: #FFFFDD;
+  padding-bottom: 150px;
+  background-color: white;
 }
 
 #second_sentence_title {
-  padding-bottom: 100px;
+  border-bottom: 3px dashed #000;
+  padding-bottom: 50px;
+  margin: 0 100px;
+  margin-bottom: 50px;
 }
 
 #third_sentence {
@@ -23,6 +28,8 @@
   background: no-repeat url('../../assets/images/tea.jpeg');
   background-size: 100% 100%;
   background-position: 50% 50%;
+  background-color: rgba(255,255,255,0.4);
+  background-blend-mode: lighten;
 }
 
 #third_sentence_title {
@@ -58,27 +65,30 @@
     padding-bottom: 450px;
     background: no-repeat url('../../assets/images/black_chair.jpeg');
     background-size: 100% 100%;
+    background-color: rgba(255,255,255,0.2);
+    background-blend-mode: lighten;
   }
   
   #first_sentence {
     width: 90%;
     padding: 0 5px;
-    padding-top: 40px;
+    padding-top: 250px;
   }
 
   #first_sentence_title {
-    color: white;
+    color: rgb(105,105,105);
   }
 
   #second_sentence {
     padding: 0 20px;
     padding-top: 100px;
     padding-bottom: 100px;
-    background-color: #FFFFDD;
   }
 
   #second_sentence_title {
-    padding-bottom: 50px;
+    border-bottom: 3px dashed #000;
+    padding-bottom: 30px;
+    margin: 0 5px;
   }
 
   #second_sentence_body {
@@ -92,9 +102,7 @@
     background: no-repeat url('../../assets/images/coffee.jpeg');
     background-size: 100% 100%;
     background-position: 50% 50%;
-  }
-
-  #third_sentence_body {
-    color: white;
+    background-color: rgba(255,255,255,0.6);
+    background-blend-mode: lighten;
   }
 }

--- a/app/javascript/stylesheets/modal.scss
+++ b/app/javascript/stylesheets/modal.scss
@@ -5,3 +5,7 @@
 .modal-body {
   background-color: rgba(221, 211, 211, 0.5);
 }
+
+.btn-secondary {
+  border-radius: 15px;
+}

--- a/app/views/bugs/_image_search_page.html.erb
+++ b/app/views/bugs/_image_search_page.html.erb
@@ -24,7 +24,8 @@
                   <%= image_tag '', id: 'image_preview', style: 'display: none;' %>
                 </div>
                 <div class="actions mb-3">
-                  <%= f.submit '検索する', class: 'btn btn-primary' %>
+                  <%= f.submit '検索する', class: 'btn orangered_btn' %>
+                  <%= link_to '閉じる', '#', class: 'btn btn-secondary', 'data-bs-dismiss': :modal %>
                 </div>
               <% end %>
             </div>

--- a/app/views/bugs/_word_search_page.html.erb
+++ b/app/views/bugs/_word_search_page.html.erb
@@ -5,7 +5,7 @@
 
 <!-- Modal -->
 <div class="modal fade" id="WordSearchModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="exampleModalLabel">虫を検索する</h5>
@@ -30,7 +30,7 @@
                 <%= f.label :size %>
                 <div class="form-control mb-3 col-4">
                   <%= f.radio_button :size, '', class: 'form-check-input' %>
-                  <%= f.label '選択してください', class: 'form-check-label', 'for': 'search_size_' %>
+                  <%= f.label '未選択', class: 'form-check-label', 'for': 'search_size_' %>
                   <%= f.radio_button :size, 'extra_small', class: 'form-check-input' %>
                   <%= f.label :size_extra_small, class: 'form-check-label' %>
                   <%= f.radio_button :size, 'small', class: 'form-check-input' %>
@@ -44,7 +44,7 @@
                 <%= f.label :color %>
                 <div class="form-control mb-3 col-4">
                   <%= f.radio_button :color, '', class: 'form-check-input' %>
-                  <%= f.label '選択してください', class: 'form-check-label', 'for': 'search_color_' %>
+                  <%= f.label '未選択', class: 'form-check-label', 'for': 'search_color_' %>
                   <%= f.radio_button :color, 'black', class: 'form-check-input' %>
                   <%= f.label 'color_black', class: 'form-check-label' %>
                   <%= f.radio_button :color, 'brown', class: 'form-check-input' %>
@@ -66,7 +66,7 @@
                 <%= f.label :season %>
                 <div class="form-control mb-3 col-4">
                   <%= f.radio_button :season, '', class: 'form-check-input' %>
-                  <%= f.label '選択してください', class: 'form-check-label', 'for': 'search_season_' %>
+                  <%= f.label '未選択', class: 'form-check-label', 'for': 'search_season_' %>
                   <%= f.radio_button :season, 'spring', class: 'form-check-input' %>
                   <%= f.label 'season_spring', class: 'form-check-label' %>
                   <%= f.radio_button :season, 'summer', class: 'form-check-input' %>
@@ -80,7 +80,7 @@
                 <%= f.label :capture %>
                 <div class="form-control mb-3">
                   <%= f.radio_button :capture, '', class: 'form-check-input' %>
-                  <%= f.label '選択してください', class: 'form-check-label', 'for': 'search_capture_' %>
+                  <%= f.label '未選択', class: 'form-check-label', 'for': 'search_capture_' %>
                   <%= f.radio_button :capture, 'high', class: 'form-check-input' %>
                   <%= f.label 'capture_high', class: 'form-check-label' %>
                   <%= f.radio_button :capture, 'normal', class: 'form-check-input' %>
@@ -92,7 +92,7 @@
                 <%= f.label :breeding %>
                 <div class="form-control mb-3">
                   <%= f.radio_button :breeding, '', class: 'form-check-input' %>
-                  <%= f.label '選択してください', class: 'form-check-label', 'for': 'search_breeding_' %>
+                  <%= f.label '未選択', class: 'form-check-label', 'for': 'search_breeding_' %>
                   <%= f.radio_button :breeding, 'high', class: 'form-check-input' %>
                   <%= f.label 'breeding_high', class: 'form-check-label' %>
                   <%= f.radio_button :breeding, 'normal', class: 'form-check-input' %>
@@ -104,7 +104,7 @@
                 <%= f.label :prevention_difficulty %>
                 <div class="form-control mb-3">
                   <%= f.radio_button :prevention_difficulty, '', class: 'form-check-input' %>
-                  <%= f.label '選択してください', class: 'form-check-label', 'for': 'search_prevention_difficulty_' %>
+                  <%= f.label '未選択', class: 'form-check-label', 'for': 'search_prevention_difficulty_' %>
                   <%= f.radio_button :prevention_difficulty, 'high', class: 'form-check-input' %>
                   <%= f.label 'prevention_difficulty_high', class: 'form-check-label' %>
                   <%= f.radio_button :prevention_difficulty, 'normal', class: 'form-check-input' %>
@@ -116,7 +116,7 @@
                 <%= f.label :injury %>
                 <div class="form-control mb-3">
                   <%= f.radio_button :injury, '', class: 'form-check-input' %>
-                  <%= f.label '選択してください', class: 'form-check-label', 'for': 'search_injury_' %>
+                  <%= f.label '未選択', class: 'form-check-label', 'for': 'search_injury_' %>
                   <%= f.radio_button :injury, 'high', class: 'form-check-input' %>
                   <%= f.label 'injury_high', class: 'form-check-label' %>
                   <%= f.radio_button :injury, 'normal', class: 'form-check-input' %>
@@ -128,7 +128,7 @@
                 <%= f.label :discomfort %>
                 <div class="form-control mb-3">
                   <%= f.radio_button :discomfort, '', class: 'form-check-input' %>
-                  <%= f.label '選択してください', class: 'form-check-label', 'for': 'search_discomfort_' %>
+                  <%= f.label '未選択', class: 'form-check-label', 'for': 'search_discomfort_' %>
                   <%= f.radio_button :discomfort, 'high', class: 'form-check-input' %>
                   <%= f.label 'discomfort_high', class: 'form-check-label' %>
                   <%= f.radio_button :discomfort, 'normal', class: 'form-check-input' %>

--- a/app/views/bugs/_word_search_page.html.erb
+++ b/app/views/bugs/_word_search_page.html.erb
@@ -139,7 +139,7 @@
                 
           
                 <div class="buttons mb-3">
-                  <%= f.submit '検索する', class: 'btn btn-primary' %>
+                  <%= f.submit '検索する', class: 'btn orangered_btn' %>
                   <%= link_to '閉じる', '#', class: 'btn btn-secondary', 'data-bs-dismiss': :modal %>
                 </div>
               <% end %>

--- a/app/views/bugs/show.html.erb
+++ b/app/views/bugs/show.html.erb
@@ -24,7 +24,7 @@
       </div>
     </div>
   </div>
-  <%= link_to '検索結果に戻る', :back %>
+  <%= link_to '検索結果に戻る', :back, class: 'btn orangered_btn' %>
   <% if current_user&.own?(@bug) %> 
     | <%= link_to '編集', edit_bug_path(@bug) %> |
     <%= link_to '削除', bug_path(@bug), method: :delete, data: { confirm: '削除してもよろしいですか？' } %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="like_unlike_button text-end">
     <% if comment.post_by(current_ip) %>
-      <%= link_to '削除', comment_path(comment), method: :delete, data: { confirm: '削除してもよろしいですか？' }, id: 'comment_delete_button', remote: true %> / 
+      <%= link_to '削除', comment_path(comment), method: :delete, data: { confirm: '削除してもよろしいですか？' }, class: 'orangered_color', id: 'comment_delete_button', remote: true %> / 
     <% end %>
     <% if comment.liked_by(current_ip) %>
       <%= render 'likes/unlike', comment: comment, current_ip: current_ip %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -6,7 +6,7 @@
     </div>
 
     <div class="actions mb-3">
-      <%= f.submit 'コメントを投稿する', class: 'btn btn-primary' %>
+      <%= f.submit 'コメントを投稿する', class: 'btn orangered_btn' %>
     </div>
   </div>
 <% end %>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -3,5 +3,5 @@
     class: 'like_button',
     method: :post,
     remote: true do %>
-  <i class="far fa-thumbs-up"></i>
+  <i class="far fa-thumbs-up orangered_color"></i>
 <% end %>

--- a/app/views/likes/_unlike.html.erb
+++ b/app/views/likes/_unlike.html.erb
@@ -3,5 +3,5 @@
     class: 'unlike_button',
     method: :delete,
     remote: true do %>
-  <i class="fas fa-thumbs-up"></i>
+  <i class="fas fa-thumbs-up orangered_color"></i>
 <% end %>

--- a/app/views/radar_charts/_radar_chart.html.erb
+++ b/app/views/radar_charts/_radar_chart.html.erb
@@ -10,10 +10,10 @@ var myChart = new Chart(ctx, {
         {
         label: "<%= bug.name %>",
         data: [<%= bug.radar_chart.capture %>, <%= bug.radar_chart.breeding %>, <%= bug.radar_chart.prevention_difficulty %>, <%= bug.radar_chart.injury %>, <%= bug.radar_chart.discomfort %>],
-        backgroundColor: 'rgba(255,99,71,0.4)',
-        borderColor: 'rgba(255,0,0)',
+        backgroundColor: 'rgba(50,205,50,0.3)',
+        borderColor: 'rgb(34,139,34)',
         borderWidth: 1,
-        pointBackgroundColor: 'rgba(255,0,0)'
+        pointBackgroundColor: 'rgb(34,139,34)'
         },
         <% if other_bug.present? %>
           {

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -7,8 +7,8 @@
     </div>
   </div>
   <div class="text-center" id="second_sentence">
-    <h3 id="second_sentence_title">＼ Message ／</h3>
-    <div id="second_sentence_body">
+    <h3 id="second_sentence_title">Message</h3>
+    <div class="pt-5" id="second_sentence_body">
       <p>アメリカで行われたある研究では、1軒あたり約100種ほどの虫が存在しているそうです。</p>
       <p>私たちは気づかないうちにたくさんの虫たちと生活を共にしているんです。</p>
     </div>


### PR DESCRIPTION
close #87 
## 概要

- トップページの画像の上に被せている文字を見やすくするために、画像を少し白くする
- 見出しのスタイルを統一させる
- PC画面のときのモーダルの幅を広くする
- セレクト検索の「選択してください」を「未選択」に変更
- 虫一覧画面での虫の名前のサイズだと改行などでずれが出やすくなるので、フォントサイズを小さくする
- サイト全体のメインカラーをライムグリーンで統一する（ボタン、リンク、タブメニュー、レーダーチャート）

## 確認方法

- トップページの画像に被っている文字が見えやすくなっていること。
- 見出しのスタイルが統一されていること。
- PC画面で検索モーダルを開いたときにモーダルの幅が大きいこと。
- セレクト検索のデフォルトの選択項目の文字が「未選択」になっていること。
- サイト全体のメインカラーがライムグリーンで統一されていること。